### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ pr:
       - doc/**/*
 
 variables:
-  v.prefix: '1.2.2'
+  v.prefix: '1.2.3'
   vmImage: 'ubuntu-latest'
 
 stages:
@@ -92,7 +92,7 @@ stages:
             displayName: nuget.org
             inputs:
               command: push
-              packagesToPush: '$(System.ArtifactsDirectory)/nuget/*.nupkg'
+              packagesToPush: '$(System.ArtifactsDirectory)/nuget/*.snupkg'
               nuGetFeedType: external
               publishFeedCredentials: 'nuget.org (aloneguid)'
           - task: GitHubRelease@1

--- a/src/IronSnappy/IronSnappy.csproj
+++ b/src/IronSnappy/IronSnappy.csproj
@@ -20,7 +20,16 @@
       <SignAssembly>true</SignAssembly>
       <AssemblyOriginatorKeyFile>fake.snk</AssemblyOriginatorKeyFile>
       
-   </PropertyGroup>
+   
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
       <DefineConstants>SPANSTREAM</DefineConstants>

--- a/src/IronSnappy/IronSnappy.csproj
+++ b/src/IronSnappy/IronSnappy.csproj
@@ -16,19 +16,18 @@
       <PackageReleaseNotes>see release history - https://github.com/aloneguid/IronSnappy/releases</PackageReleaseNotes>
       <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
       <Authors>Ivan Gavryliuk (@aloneguid)</Authors>
-      
+
       <SignAssembly>true</SignAssembly>
       <AssemblyOriginatorKeyFile>fake.snk</AssemblyOriginatorKeyFile>
-      
-   
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
+      <PublishRepositoryUrl>true</PublishRepositoryUrl>
+      <IncludeSymbols>true</IncludeSymbols>
+      <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+   </PropertyGroup>
+
+   <ItemGroup>
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+   </ItemGroup>
 
 
    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
@@ -40,7 +39,7 @@
    </ItemGroup>
 
    <ItemGroup>
-     <None Include="icon.png" Pack="true" PackagePath="" />
+      <None Include="icon.png" Pack="true" PackagePath="" />
    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
